### PR TITLE
Tidy layer2 scripts

### DIFF
--- a/platform/cleanup/layer2_cleanup.sh
+++ b/platform/cleanup/layer2_cleanup.sh
@@ -28,27 +28,9 @@ for ((k=0;k<group_numbers;k++)); do
     group_layer2_hosts="${group_k[6]}"
     group_layer2_links="${group_k[7]}"
 
-    if [ "${group_as}" != "IXP" ];then
-
-        readarray routers < "${DIRECTORY}"/config/$group_router_config
-        readarray l2_switches < "${DIRECTORY}"/config/$group_layer2_switches
-        readarray l2_hosts < "${DIRECTORY}"/config/$group_layer2_hosts
-        readarray l2_links < "${DIRECTORY}"/config/$group_layer2_links
-        n_routers=${#routers[@]}
-        n_l2_switches=${#l2_switches[@]}
-        n_l2_links=${#l2_links[@]}
-        n_l2_hosts=${#l2_hosts[@]}
-
-        for ((i=0;i<n_routers;i++)); do
-            router_i=(${routers[$i]})
-            rname="${router_i[0]}"
-            property1="${router_i[1]}"
-            property2="${router_i[2]}"
-            if [[ "${property2}" == *L2* ]];then
-                br_name="l2-"${group_number}
-                echo -n "-- --if-exists del-br "${br_name}" " >> "${DIRECTORY}"/ovs_command.txt
-            fi
-        done
+    if [ "${group_as}" != "IXP" ]; then
+        br_name="l2-"${group_number}
+        echo -n "-- --if-exists del-br "${br_name}" " >> "${DIRECTORY}"/ovs_command.txt
     fi
 done
 

--- a/platform/setup/layer2_setup.sh
+++ b/platform/setup/layer2_setup.sh
@@ -44,6 +44,11 @@ for ((k=0;k<group_numbers;k++)); do
         n_l2_hosts=${#l2_hosts[@]}
         n_l2_links=${#l2_links[@]}
 
+        if [ "${n_l2_links}" = "0" -a "${n_l2_links}" = "0" -a "${n_l2_links}" = "0" ]; then
+            # No L2 config, skip
+            continue
+        fi
+
         br_name="l2-"${group_number}
         echo -n "-- add-br "${br_name}" " >> "${DIRECTORY}"/groups/add_bridges.sh
         echo "ovs-vsctl set bridge "${br_name}" other-config:forward-bpdu=true" >> "${DIRECTORY}"/groups/l2_init_switch.sh


### PR DESCRIPTION
I found the cleanup script missed cleaning the ovs l2-<group> bridge for ASes with an empty l2 network.
This change both prevents creating the bridge in the first place and ensures such a bridge would always be cleaned up.