### PR TITLE
Debian 10/Ubuntu 20.04 fixes

### DIFF
--- a/platform/portforwarding.sh
+++ b/platform/portforwarding.sh
@@ -20,14 +20,18 @@ for ((k=0;k<group_numbers;k++)); do
     group_as="${group_k[1]}"
 
     if [ "${group_as}" != "IXP" ];then
-        ufw allow "$((group_number+2000))"
+        if command -v ufw > /dev/null 2>&1; then
+            ufw allow "$((group_number+2000))"
+        fi
         subnet=$(subnet_ext_sshContainer "${group_number}" "sshContainer")
         ssh -i groups/id_rsa -o "StrictHostKeyChecking no" -f -N -L 0.0.0.0:"$((group_number+2000))":"${subnet%/*}":22 root@${subnet%/*}
     fi
 done
 
 # measurement
-ufw allow 2099
+if command -v ufw > /dev/null 2>&1; then
+    ufw allow 2099
+fi
 subnet=$(subnet_ext_sshContainer "${group_number}" "MEASUREMENT")
 ssh -i groups/id_rsa -o "StrictHostKeyChecking no" -f -N -L 0.0.0.0:2099:"${subnet%/*}":22 root@${subnet%/*}
 

--- a/platform/setup/vpn_config.sh
+++ b/platform/setup/vpn_config.sh
@@ -93,8 +93,12 @@ for ((k=0;k<group_numbers;k++)); do
                         -CAcreateserial -CAserial $location/ca.srl 2>/dev/null
                 done
 
-                DH_KEY_SIZE=512
-                openssl dhparam -out $location/dh.pem ${DH_KEY_SIZE} 2>/dev/null
+                if grep "SECLEVEL=2" /etc/ssl/openssl.cnf ; then
+                    DH_KEY_SIZE=2048
+                else
+                    DH_KEY_SIZE=512
+                fi
+                openssl dhparam -dsaparam -out $location/dh.pem ${DH_KEY_SIZE} 2>/dev/null
 
 
                 echo "proto udp" >> $location/server.conf


### PR DESCRIPTION
Some fixes for newer Linux distributions (such as Ubuntu 20.04 and Debian 10):

- Generate a 2048 bit key if SECLEVEL=2 is set in openssl, otherwise use a 512 bit key.
- Improve key generation speed with the -dsaparam option.
- Only run ufw if it is installed.