### PR TITLE
Fix: ifconfig replacement with ip (link up)

### DIFF
--- a/platform/setup/dns_setup.sh
+++ b/platform/setup/dns_setup.sh
@@ -22,7 +22,7 @@ chmod +x "${DIRECTORY}"/groups/dns_routes.sh
 docker run -itd --net='none'  --name="DNS" --privileged thomahol/d_dns
 
 echo -n "-- add-br dns " >> "${DIRECTORY}"/groups/add_bridges.sh
-echo "ip a add 0.0.0.0 dev dns" >> "${DIRECTORY}"/groups/ip_setup.sh
+echo "ip link set dev dns up" >> "${DIRECTORY}"/groups/ip_setup.sh
 
 for ((k=0;k<group_numbers;k++)); do
     group_k=(${groups[$k]})
@@ -76,7 +76,7 @@ subnet_dns="$(subnet_router_DNS -1 "dns")"
 subnet_measurement="$(subnet_router_DNS -1 "measurement")"
 
 echo -n "-- add-br "${br_name}" ">> "${DIRECTORY}"/groups/add_bridges.sh
-echo "ip a add 0.0.0.0 dev "${br_name} >> "${DIRECTORY}"/groups/ip_setup.sh
+echo "ip link set dev ${br_name} up" >> "${DIRECTORY}"/groups/ip_setup.sh
 ./setup/ovs-docker.sh add-port "${br_name}" measurement DNS --ipaddress="${subnet_dns}"
 ./setup/ovs-docker.sh add-port "${br_name}" dns MEASUREMENT --ipaddress="${subnet_measurement}"
 echo "docker exec -d DNS ip route add "${subnet_measurement%/*}" dev measurement " >> "${DIRECTORY}"/groups/dns_routes.sh

--- a/platform/setup/external_links_setup.sh
+++ b/platform/setup/external_links_setup.sh
@@ -53,7 +53,7 @@ for ((i=0;i<n_extern_links;i++)); do
         br_name="ixp-""${grp_2}""-""${grp_1}"
 
         echo -n "-- add-br "${br_name}" " >> "${DIRECTORY}"/groups/add_bridges.sh
-        echo "ip a add 0.0.0.0 dev ${br_name}" >> "${DIRECTORY}"/groups/ip_setup.sh
+        echo "ip link set dev ${br_name} up" >> "${DIRECTORY}"/groups/ip_setup.sh
 
         ./setup/ovs-docker.sh add-port  "${br_name}" ixp_"${grp_2}" \
           "${grp_1}"_"${router_grp_1}"router --delay="${delay}" --throughput="${throughput}"
@@ -63,7 +63,7 @@ for ((i=0;i<n_extern_links;i++)); do
         br_name="ext-""${i}"
 
         echo -n "-- add-br "${br_name}" " >> "${DIRECTORY}"/groups/add_bridges.sh
-        echo "ip a add 0.0.0.0 dev ${br_name}" >> "${DIRECTORY}"/groups/ip_setup.sh
+        echo "ip link set dev ${br_name} up" >> "${DIRECTORY}"/groups/ip_setup.sh
 
         ./setup/ovs-docker.sh add-port  "${br_name}" ext_"${grp_2}"_"${router_grp_2}" \
         "${grp_1}"_"${router_grp_1}"router --delay="${delay}" --throughput="${throughput}"

--- a/platform/setup/host_links_setup.sh
+++ b/platform/setup/host_links_setup.sh
@@ -57,7 +57,8 @@ for ((k=0;k<group_numbers;k++)); do
 
                 # set default ip address and default gw in host
                 if [ "$group_config" == "Config" ]; then
-                    echo "docker exec -d "${group_number}"_"${rname}"host ifconfig "${rname}"router "${subnet_host}" up" >> "${DIRECTORY}"/groups/ip_setup.sh
+                    echo "docker exec -d "${group_number}"_"${rname}"host ip a add "${subnet_host}" dev "${rname}"router" >> "${DIRECTORY}"/groups/ip_setup.sh
+                    echo "docker exec -d "${group_number}"_"${rname}"host ip link set dev "${rname}"router up" >> "${DIRECTORY}"/groups/ip_setup.sh
                     echo "docker exec -d "${group_number}"_"${rname}"host ip route add default via "${subnet_router%/*} >> "${DIRECTORY}"/groups/ip_setup.sh
                 fi
             fi

--- a/platform/setup/internal_links_setup.sh
+++ b/platform/setup/internal_links_setup.sh
@@ -35,7 +35,7 @@ for ((k=0;k<group_numbers;k++)); do
             br_name="int-""${group_number}"
 
             echo -n "-- add-br "${br_name}" " >> "${DIRECTORY}"/groups/add_bridges.sh
-            echo "ip a add 0.0.0.0 dev "${br_name} >> "${DIRECTORY}"/groups/ip_setup.sh
+            echo "ip link set dev ${br_name} up" >> "${DIRECTORY}"/groups/ip_setup.sh
 
             for ((i=0;i<n_intern_links;i++)); do
                 row_i=(${intern_links[$i]})

--- a/platform/setup/layer2_config.sh
+++ b/platform/setup/layer2_config.sh
@@ -103,7 +103,9 @@ for ((k=0;k<group_numbers;k++)); do
                     subnet_host=$(subnet_l2 $group_number $((${l2_id["L2-"$l2name]}-1)) $vlan $((${vlanl2set["L2-"${l2name}-${vlan}]}+${l2_routerid["L2-"$l2name]})))
 
                     docker exec -d ${group_number}_L2_${l2name}_${hname} \
-                        ifconfig ${group_number}-${sname} $subnet_host up
+                        ip a add $subnet_host dev ${group_number}-${sname}
+                    docker exec -d ${group_number}_L2_${l2name}_${hname} \
+                        ip link set dev ${group_number}-${sname} up
 
                     subnet_gw="$(subnet_l2 ${group_number} $((${l2_id["L2-"$l2name]}-1)) ${vlan} 1)"
 

--- a/platform/setup/layer2_setup.sh
+++ b/platform/setup/layer2_setup.sh
@@ -117,11 +117,11 @@ for ((k=0;k<group_numbers;k++)); do
                 echo "ip link add ${group_number}-$hname type veth peer name g${group_number}_$hname" >> "${DIRECTORY}"/groups/add_vpns.sh
                 echo "PID=$(sudo docker inspect -f '{{.State.Pid}}' "${group_number}_L2_${l2name}_${sname}")" >> "${DIRECTORY}"/groups/add_vpns.sh
                 echo "ip link set ${group_number}-$hname netns \$PID" >> "${DIRECTORY}"/groups/add_vpns.sh
-                echo "docker exec -d "${group_number}""_L2_""${l2name}_${sname}" ifconfig ${group_number}-$hname 0.0.0.0 up" >> "${DIRECTORY}"/groups/add_vpns.sh
+                echo "docker exec -d "${group_number}""_L2_""${l2name}_${sname}" ip link set dev ${group_number}-$hname up" >> "${DIRECTORY}"/groups/add_vpns.sh
                 echo "docker exec -d "${group_number}""_L2_""${l2name}_${sname}" ovs-vsctl add-port br0 ${group_number}-$hname" >> "${DIRECTORY}"/groups/add_vpns.sh
 
-                echo "ip a add 0.0.0.0 dev g${group_number}_$hname" >> groups/add_vpns.sh
-                echo "ip a add 0.0.0.0 dev tap_g"${group_number}_$hname >> groups/add_vpns.sh
+                echo "ip link set dev g${group_number}_$hname up" >> groups/add_vpns.sh
+                echo "ip link set dev tap_g${group_number}_$hname up" >> groups/add_vpns.sh
 
                 echo "sudo ovs-vsctl add-port vpnbr_${group_k}_${host_l} tap_g"${group_number}_$hname >> groups/add_vpns.sh
                 echo "sudo ovs-vsctl add-port vpnbr_${group_k}_${host_l} g${group_number}_$hname" >> groups/add_vpns.sh

--- a/platform/setup/matrix_setup.sh
+++ b/platform/setup/matrix_setup.sh
@@ -29,7 +29,7 @@ docker run -itd --net='none' --name="MATRIX" --privileged --pids-limit 500 \
 docker exec -d MATRIX bash -c 'sysctl -w net.ipv4.icmp_ratelimit="0" > /dev/null' &
 
 echo -n "-- add-br matrix " >> "${DIRECTORY}"/groups/add_bridges.sh
-echo "ip a add 0.0.0.0 dev matrix" >> "${DIRECTORY}"/groups/ip_setup.sh
+echo "ip link set dev matrix up" >> "${DIRECTORY}"/groups/ip_setup.sh
 
 for ((k=0;k<group_numbers;k++)); do
     group_k=(${groups[$k]})

--- a/platform/setup/measurement_setup.sh
+++ b/platform/setup/measurement_setup.sh
@@ -29,7 +29,7 @@ subnet_ssh_measurement="$(subnet_ext_sshContainer -1 "MEASUREMENT")"
 ./setup/ovs-docker.sh add-port ssh_to_group ssh_in MEASUREMENT --ipaddress="${subnet_ssh_measurement}"
 
 echo -n "-- add-br measurement " >> "${DIRECTORY}"/groups/add_bridges.sh
-echo "ip a add 0.0.0.0 dev measurement" >> "${DIRECTORY}"/groups/ip_setup.sh
+echo "ip link set dev measurement up" >> "${DIRECTORY}"/groups/ip_setup.sh
 
 for ((k=0;k<group_numbers;k++)); do
     group_k=(${groups[$k]})

--- a/platform/setup/ssh_setup.sh
+++ b/platform/setup/ssh_setup.sh
@@ -18,6 +18,7 @@ echo -n "-- add-br ssh_to_group " >> "${DIRECTORY}"/groups/add_bridges.sh
 
 subnet_bridge="$(subnet_ext_sshContainer -1 "bridge")"
 echo "ip a add $subnet_bridge dev ssh_to_group" >> "${DIRECTORY}"/groups/ip_setup.sh
+echo "ip link set dev ssh_to_group up" >> "${DIRECTORY}"/groups/ip_setup.sh
 
 # General a pair of keys for the server, and put the public in the proxy container
 ssh-keygen -t rsa -b 4096 -C "comment" -P "" -f "groups/id_rsa" -q
@@ -68,7 +69,7 @@ for ((k=0;k<group_numbers;k++)); do
         subnet_ssh_to_cont="$(subnet_sshContainer_groupContainer "${group_number}" -1 -1 "sshContainer")"
 
         echo -n "-- add-br "${group_number}"-ssh " >> "${DIRECTORY}"/groups/add_bridges.sh
-        echo "ip a add 0.0.0.0 dev "${group_number}"-ssh" >> "${DIRECTORY}"/groups/ip_setup.sh
+        echo "ip link set dev ${group_number}-ssh up" >> "${DIRECTORY}"/groups/ip_setup.sh
 
 
         # Connect the proxy container to the virtual devices


### PR DESCRIPTION
Thanks for merging these so quickly @KTrel.

The replacements (dbce6b7 d41a221) of ```ifconfig``` with ```ip``` missed setting the link up.

* ```ifconfig <interface> 0.0.0.0 up```
Should have been replaced with:
```ip link set dev <interface> up```

* Replaces a few more instances of ```ifconfig``` with ```ip```