### PR TITLE
Update 'route' command to 'ip route' in layer2_config

### DIFF
--- a/platform/setup/layer2_config.sh
+++ b/platform/setup/layer2_config.sh
@@ -125,7 +125,7 @@ for ((k=0;k<group_numbers;k++)); do
                     subnet_gw="$(subnet_l2 ${group_number} $((${l2_id["L2-"$l2name]}-1)) ${vlan} 1)"
 
                     ip netns exec $PID \
-                        route add default gw ${subnet_gw%/*}
+                        ip route add default via ${subnet_gw%/*}
                 fi
             fi
 


### PR DESCRIPTION
Hello,
Just a small suggestion to replace the "route" command from net-tools by the "ip" command from iproute2 (in the layer2_config.sh script).
Best regards,
Emmanuel