### PR TITLE
Periodically check ssh sessions are alive

### DIFF
--- a/platform/docker_images/measurement/docker-start
+++ b/platform/docker_images/measurement/docker-start
@@ -5,13 +5,13 @@ set -e
 mkdir -p /root/.ssh
 mkdir -p /var/run/sshd
 chmod 0755 /var/run/sshd
-/usr/sbin/sshd
 
 sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/g' /etc/ssh/sshd_config
 sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config
+sed -i 's/#ClientAliveInterval 0/ClientAliveInterval 60/g' /etc/ssh/sshd_config
+sed -i 's/#ClientAliveCountMax 3/ClientAliveCountMax 3/g' /etc/ssh/sshd_config
 
-
-service ssh restart
+/usr/sbin/sshd
 
 cp /launch_traceroute.sh /root/launch_traceroute.sh
 

--- a/platform/docker_images/ssh/docker-start
+++ b/platform/docker_images/ssh/docker-start
@@ -5,10 +5,12 @@ set -e
 mkdir -p /root/.ssh
 mkdir -p /var/run/sshd
 chmod 0755 /var/run/sshd
-/usr/sbin/sshd
 
 sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/g' /etc/ssh/sshd_config
 sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config
+sed -i 's/#ClientAliveInterval 0/ClientAliveInterval 60/g' /etc/ssh/sshd_config
+sed -i 's/#ClientAliveCountMax 3/ClientAliveCountMax 3/g' /etc/ssh/sshd_config
 
+/usr/sbin/sshd
 
 tail -f /dev/null # To keep the container running forever


### PR DESCRIPTION
A fix for the issue where students do not cleanly close their ssh sessions and they hit their process limit.
Checks ssh connections are alive after 60 seconds of inactivity.

I ran with this fix this year and didn't have any students hit their process limit.