### PR TITLE
Fix cleanup and logic of hosts attached L2 routers

### DIFF
--- a/platform/cleanup/container_cleanup.sh
+++ b/platform/cleanup/container_cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# delere all group containers(ssh, routers, hosts, switches), DNS, MEASUREMENT and MATRIX
+# delete all group containers(ssh, routers, hosts, switches), DNS, MEASUREMENT and MATRIX
 
 set -o errexit
 set -o pipefail
@@ -42,15 +42,18 @@ for ((k=0;k<group_numbers;k++)); do
             rname="${router_i[0]}"
             property1="${router_i[1]}"
             property2="${router_i[2]}"
+            dname=$(echo $property2 | cut -s -d ':' -f 2)
 
             # kill router router
             docker kill "${group_number}""_""${rname}""router" &>/dev/null || true &
 
-            # kill host or layer 2
-            if [ "$(echo ${property2} | sed 's/:.*//g')" == "host" ]; then
+            # kill host
+            if [[ ! -z "${dname}" ]]; then
                 docker kill "${group_number}""_""${rname}""host" &>/dev/null || true &
+            fi
 
-            elif [[ "${property2}" == *L2* ]];then
+            # cleanup layer 2
+            if [[ "${property2}" == *L2* ]];then
                 # kill switches
                 for ((l=0;l<n_l2_switches;l++)); do
                     switch_l=(${l2_switches[$l]})

--- a/platform/setup/container_setup.sh
+++ b/platform/setup/container_setup.sh
@@ -109,7 +109,7 @@ for ((k=0;k<group_numbers;k++)); do
             rname="${router_i[0]}"
             property1="${router_i[1]}"
             property2="${router_i[2]}"
-            dname=$(echo $property2 | cut -d ':' -f 2)
+            dname=$(echo $property2 | cut -s -d ':' -f 2)
 
             location="${DIRECTORY}"/groups/g"${group_number}"/"${rname}"
 

--- a/platform/setup/dns_config.sh
+++ b/platform/setup/dns_config.sh
@@ -124,7 +124,7 @@ for ((j=0;j<n_groups;j++)); do
             rname="${router_i[0]}"
             property1="${router_i[1]}"
             property2="${router_i[2]}"
-            dname=$(echo $property2 | cut -d ':' -f 2)
+            dname=$(echo $property2 | cut -s -d ':' -f 2)
 
             if [[ ! -z "${dname}" ]];then
                 subnet1="$(subnet_host_router "${group_number}" "$i" "host")"

--- a/platform/setup/goto_scripts.sh
+++ b/platform/setup/goto_scripts.sh
@@ -63,7 +63,7 @@ for ((k=0;k<n_groups;k++)); do
             property1="${router_i[1]}"
             property2="${router_i[2]}"
             rcmd="${router_i[3]}"
-            dname=$(echo $property2 | cut -d ':' -f 2)
+            dname=$(echo $property2 | cut -s -d ':' -f 2)
             l2_name=$(echo $property2 | cut -d ':' -f 1 | cut -f 2 -d '-')
 
             if [[ ${l2_id[$l2_name]} == 1000000 ]]; then

--- a/platform/setup/host_links_setup.sh
+++ b/platform/setup/host_links_setup.sh
@@ -39,7 +39,7 @@ for ((k=0;k<group_numbers;k++)); do
             rname="${router_i[0]}"
             property1="${router_i[1]}"
             property2="${router_i[2]}"
-            dname=$(echo $property2 | cut -d ':' -f 2)
+            dname=$(echo $property2 | cut -s -d ':' -f 2)
 
             if [[ ! -z "${dname}" ]];then
 

--- a/platform/setup/router_config.sh
+++ b/platform/setup/router_config.sh
@@ -67,7 +67,7 @@ for ((k=0;k<group_numbers;k++));do
             rname="${router_i[0]}"
             property1="${router_i[1]}"
             property2="${router_i[2]}"
-            dname=$(echo $property2 | cut -d ':' -f 2)
+            dname=$(echo $property2 | cut -s -d ':' -f 2)
 
             if [ ${#rname} -gt 10 ]; then
                 echo 'ERROR: Router names must have a length lower or equal than 10'

--- a/platform/setup/ssh_setup.sh
+++ b/platform/setup/ssh_setup.sh
@@ -86,7 +86,7 @@ for ((k=0;k<group_numbers;k++)); do
             property1="${router_i[1]}"
             property2="${router_i[2]}"
             rcmd="${router_i[3]}"
-            dname=$(echo $property2 | cut -d ':' -f 2)
+            dname=$(echo $property2 | cut -s -d ':' -f 2)
             l2_switch_cur=0
             l2_host_cur=0
 


### PR DESCRIPTION
- This is a small fix to the cleanup.sh script to delete hosts attached to L2 routers
- Additionally I've fixed what appears to be a bug where a router where the router config ```GENE    N/A     L2-UNIV``` would try and start a docker image called L2-UNIV. This commit skips creating the host unless a docker image is also supplied e.g. ```L2-UNIV:thomahol/d_host```. I don't know what was intended in this situation, perhaps it is better to fail in this case?