### PR TITLE
Small improves to the measurement container

### DIFF
--- a/platform/docker_images/measurement/launch_traceroute.sh
+++ b/platform/docker_images/measurement/launch_traceroute.sh
@@ -5,6 +5,8 @@ if [ $# -ne 2 ]; then
     exit 1
 fi
 
+trap "exit" SIGINT
+
 src_grp=$1
 dst_ip=$2
 

--- a/platform/setup/dns_setup.sh
+++ b/platform/setup/dns_setup.sh
@@ -38,7 +38,7 @@ if [[ "$is_dns" -eq 0 ]]; then
     echo "There is no DNS server, skipping dns_setup.sh"
 else
     # dns
-    docker run -itd --net='none' --name="DNS" --privileged \
+    docker run -itd --net='none' --name="DNS" --hostname="DNS" --privileged \
         -v /etc/timezone:/etc/timezone:ro \
         -v /etc/localtime:/etc/localtime:ro \
         thomahol/d_dns

--- a/platform/setup/matrix_setup.sh
+++ b/platform/setup/matrix_setup.sh
@@ -41,7 +41,8 @@ else
 
 
     # start matrix container
-    docker run -itd --net='none' --name="MATRIX" --privileged --pids-limit 500 \
+    docker run -itd --net='none' --name="MATRIX" --hostname="MATRIX" \
+        --privileged --pids-limit 500 \
         --sysctl net.ipv4.icmp_ratelimit=0 \
         -v /etc/timezone:/etc/timezone:ro \
         -v /etc/localtime:/etc/localtime:ro \

--- a/platform/setup/measurement_setup.sh
+++ b/platform/setup/measurement_setup.sh
@@ -37,7 +37,7 @@ else
     subnet_dns="$(subnet_router_DNS -1 "dns")"
     docker run -itd --net='none' --dns="${subnet_dns%/*}" \
         --sysctl net.ipv4.icmp_ratelimit=0 \
-        --name="MEASUREMENT" --cpus=2 --pids-limit 100 \
+        --name="MEASUREMENT" --hostname="MEASUREMENT" --cpus=2 --pids-limit 100 \
         -v /etc/timezone:/etc/timezone:ro \
         -v /etc/localtime:/etc/localtime:ro \
         --cap-add=NET_ADMIN thomahol/d_measurement


### PR DESCRIPTION
- Ctrl-C to kill measurement ./launch_traceroute.sh script early
- Set the hostname of the measurement, matrix and dns containers, so that the name shows on the terminal