### PR TITLE
Set OvS fail-mode to secure on bridges with flow rules installed

### DIFF
--- a/platform/setup/dns_setup.sh
+++ b/platform/setup/dns_setup.sh
@@ -49,7 +49,7 @@ else
     declare -p DOCKER_TO_PID > "${DIRECTORY}/groups/docker_pid.map"
     source "${DIRECTORY}/setup/ovs-docker.sh"
 
-    echo -n "-- add-br dns " >> "${DIRECTORY}"/groups/add_bridges.sh
+    echo -n "-- add-br dns -- set-fail-mode dns secure  " >> "${DIRECTORY}"/groups/add_bridges.sh
     echo "ip link set dev dns up" >> "${DIRECTORY}"/groups/ip_setup.sh
 
     get_docker_pid DNS

--- a/platform/setup/host_links_setup.sh
+++ b/platform/setup/host_links_setup.sh
@@ -31,7 +31,7 @@ for ((k=0;k<group_numbers;k++)); do
 
         br_name="${group_number}"-host
 
-        echo -n "-- add-br "${br_name}" " >> "${DIRECTORY}"/groups/add_bridges.sh
+        echo -n "-- add-br "${br_name}" -- set-fail-mode "${br_name}" secure " >> "${DIRECTORY}"/groups/add_bridges.sh
         echo "ip a add 0.0.0.0 dev ${br_name}" >> "${DIRECTORY}"/groups/ip_setup.sh
 
         for ((i=0;i<n_routers;i++)); do

--- a/platform/setup/internal_links_setup.sh
+++ b/platform/setup/internal_links_setup.sh
@@ -34,7 +34,7 @@ for ((k=0;k<group_numbers;k++)); do
 
             br_name="int-""${group_number}"
 
-            echo -n "-- add-br "${br_name}" " >> "${DIRECTORY}"/groups/add_bridges.sh
+            echo -n "-- add-br "${br_name}" -- set-fail-mode "${br_name}" secure " >> "${DIRECTORY}"/groups/add_bridges.sh
             echo "ip link set dev ${br_name} up" >> "${DIRECTORY}"/groups/ip_setup.sh
 
             for ((i=0;i<n_intern_links;i++)); do

--- a/platform/setup/layer2_setup.sh
+++ b/platform/setup/layer2_setup.sh
@@ -51,7 +51,7 @@ for ((k=0;k<group_numbers;k++)); do
         fi
 
         br_name="l2-"${group_number}
-        echo -n "-- add-br "${br_name}" " >> "${DIRECTORY}"/groups/add_bridges.sh
+        echo -n "-- add-br "${br_name}" -- set-fail-mode "${br_name}" secure " >> "${DIRECTORY}"/groups/add_bridges.sh
         echo "ovs-vsctl set bridge "${br_name}" other-config:forward-bpdu=true" >> "${DIRECTORY}"/groups/l2_init_switch.sh
 
         for ((l=0;l<n_l2_switches;l++)); do

--- a/platform/setup/matrix_setup.sh
+++ b/platform/setup/matrix_setup.sh
@@ -54,7 +54,7 @@ else
     DOCKER_TO_PID['MATRIX']=$(docker inspect -f '{{.State.Pid}}' MATRIX)
     declare -p DOCKER_TO_PID > ${DIRECTORY}/groups/docker_pid.map
 
-    echo -n "-- add-br matrix " >> "${DIRECTORY}"/groups/add_bridges.sh
+    echo -n "-- add-br matrix -- set-fail-mode matrix secure " >> "${DIRECTORY}"/groups/add_bridges.sh
     echo "ip link set dev matrix up" >> "${DIRECTORY}"/groups/ip_setup.sh
 
     for ((k=0;k<group_numbers;k++)); do

--- a/platform/setup/measurement_setup.sh
+++ b/platform/setup/measurement_setup.sh
@@ -54,7 +54,7 @@ else
     subnet_ssh_measurement="$(subnet_ext_sshContainer -1 "MEASUREMENT")"
     ./setup/ovs-docker.sh add-port ssh_to_group ssh_in MEASUREMENT --ipaddress="${subnet_ssh_measurement}"
 
-    echo -n "-- add-br measurement " >> "${DIRECTORY}"/groups/add_bridges.sh
+    echo -n "-- add-br measurement -- set-fail-mode measurement secure " >> "${DIRECTORY}"/groups/add_bridges.sh
     echo "ip link set dev measurement up" >> "${DIRECTORY}"/groups/ip_setup.sh
 
     for ((k=0;k<group_numbers;k++)); do

--- a/platform/utils/recover_ovs_flows.sh
+++ b/platform/utils/recover_ovs_flows.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Reinstalls OvS flow rules and brings up related interfaces.
+# For use if main OvS instance was accidentally restarted etc.
+# This script pulls commands out of groups/ip_setup.sh.
+
+new_script=_recover_ovs_flows.sh
+ip_setup=../groups/ip_setup.sh
+
+rm "${new_script}" 2>/dev/null
+touch "${new_script}"
+while read -r line; do
+  case "$line" in
+  'port_id1=`ovs-vsctl get Interface'*)
+    echo "$line" >>"${new_script}"
+    ;;
+  'port_id2=`ovs-vsctl get Interface'*)
+    echo "$line" >>"${new_script}"
+    ;;
+  'ovs-ofctl add-flow'*)
+    echo "$line" >>"${new_script}"
+    ;;
+  *netns*);;  # Skip netns related lines, these interfaces are within containers
+  PID*);;
+  '#'*);;
+  source*);;
+  *)          # The remaining commands configure interfaces in the main OvS instance
+  echo "$line" >>"${new_script}"
+  ;;
+  esac
+done <"$ip_setup"
+
+chmod +x "${new_script}"
+
+echo "OvS commands written to ${new_script}"
+read -p "Would you like to reinstall OvS flows now? [y/N]" -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo "Cancelled"
+  exit 1
+else
+  sudo ./${new_script}
+  echo "OvS flows have been installed"
+fi


### PR DESCRIPTION
This patch configures the OvS bridges that have explicit flow rules to link ports together with fail-mode secure. So that they don't default back to normal switching behaviour if those flows are lost, which can cause unexpected loops etc.

I hit this issue this year when an automatic security update for the python OvS bindings reloaded OvS.
I have also included a script to recover from this scenario.