### PR TITLE
Some small ssh/proxy host improvements

### DIFF
--- a/platform/docker_images/ssh/Dockerfile
+++ b/platform/docker_images/ssh/Dockerfile
@@ -12,5 +12,7 @@ ENV LC_ALL en_US.UTF-8
 ADD docker-start /usr/sbin/docker-start
 ADD goto_completion /root/.goto_completion
 RUN echo "source ~/.goto_completion" >> /root/.bashrc
+# Warn students trying to run ssh-keygen on the ssh host, they have misunderstood where to run it
+RUN echo alias ssh-keygen=\"echo You should not be running ssh-keygen on the proxy host. Instead, run ssh-keygen on your remote machine, e.g. the lab machine. Then run ssh-copy-id on your remote machine to authorize your key on the proxy host.\" >> ~/.bashrc
 RUN chmod +x /usr/sbin/docker-start
 ENTRYPOINT ["/usr/sbin/docker-start"]

--- a/platform/docker_images/ssh/Dockerfile
+++ b/platform/docker_images/ssh/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:stretch
-RUN apt-get update && apt-get install -y rsyslog vim locales iputils-ping openssh-server less zip
+RUN apt-get update && apt-get install -y rsyslog vim locales iputils-ping \
+	openssh-server less zip tmux screen
 
 # Set locale
 RUN sed -i -e 's/# \(en_US\.UTF-8 .*\)/\1/' /etc/locale.gen && \


### PR DESCRIPTION
Alias ssh-keygen to a warning in bashrc so that students cannot accidentally overwrite the preconfigured ssh keys.
Installs tmux and screen to the ssh host.