### PR TITLE
adding vtysh column to default router config files to prevent crash during default setup

### DIFF
--- a/platform/config/router_config_full.txt
+++ b/platform/config/router_config_full.txt
@@ -1,8 +1,8 @@
-LOND	DNS	host:thomahol/d_host
-ZURI	MEASUREMENT	L2-UNIV
-PARI	MATRIX host:thomahol/d_host
-GENE	N/A	L2-UNIV
-NEWY	N/A	host:thomahol/d_host
-BOST	N/A	host:thomahol/d_host
-ATLA	MATRIX_TARGET  host:thomahol/d_host
-MIAM	N/A	host:thomahol/d_host
+LOND	DNS	host:thomahol/d_host    vtysh
+ZURI	MEASUREMENT	L2-UNIV:thomahol/d_host vtysh
+PARI	MATRIX host:thomahol/d_host vtysh
+GENE	N/A	L2-UNIV:thomahol/d_host vtysh
+NEWY	N/A	host:thomahol/d_host    vtysh
+BOST	N/A	host:thomahol/d_host    vtysh
+ATLA	MATRIX_TARGET  host:thomahol/d_host vtysh
+MIAM	N/A	host:thomahol/d_host    vtysh

--- a/platform/config/router_config_small.txt
+++ b/platform/config/router_config_small.txt
@@ -1,2 +1,2 @@
-LOND    MATRIX host:thomahol/d_host
-ZURI    MATRIX_TARGET host:thomahol/d_host
+LOND    MATRIX host:thomahol/d_host vtysh
+ZURI    MATRIX_TARGET host:thomahol/d_host  vtysh


### PR DESCRIPTION
Small fix to make sure the two default router config files also contain the newely added column to control if the goto script only allows router CLI access or also access to the container hosting the router.

Without this column, the setup process crashes.