### PR TITLE
Change the name of the external link file in Hijacks script

### DIFF
--- a/platform/utils/hijacks/hijack.sh
+++ b/platform/utils/hijacks/hijack.sh
@@ -44,7 +44,7 @@ run_hijack () {
 
     # read configs
     readarray groups < config/AS_config.txt
-    readarray extern_links < config/external_links_config.txt
+    readarray extern_links < config/external_links_config_students.txt
 
     group_numbers=${#groups[@]}
     n_extern_links=${#extern_links[@]}


### PR DESCRIPTION
Hello,

I noticed that the hijack script is still using the old naming convention of external link file and fail to run.

I updated it to use the new "external_links_config_students.txt" filename.
I tried it like that and it works again.

Best regards,