### PR TITLE
Migrate IXPs from Quagga to FRR

### DIFF
--- a/platform/docker_images/ixp/Dockerfile
+++ b/platform/docker_images/ixp/Dockerfile
@@ -1,63 +1,35 @@
-FROM ubuntu:xenial
+FROM d_base_supervisor:latest
 
-# Install dependencies
-RUN apt-get update && apt-get install -y curl wget openvswitch-switch openvswitch-common \
-        vim openssh-server inetutils-traceroute net-tools tcpdump quagga \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache openssh-server openvswitch frr frr-rpki frr-pythontools \
+    && ssh-keygen -A \
+    && sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config \
+    && sed -i 's/#PrintMotd yes/PrintMotd no/g' /etc/ssh/sshd_config \
+    # Unlocks the root user so that ssh login is allowed.
+    && sed -i s/root:!/"root:*"/g /etc/shadow \
+    && mkdir -p /var/run/sshd /root/.ssh \
+    && chmod 0755 /var/run/sshd
 
-RUN echo "export VTYSH_PAGER=more" >>  /etc/bash.bashrc
-RUN echo "VTYSH_PAGER=more" >> /etc/environment
+RUN install -m 755 -o frr -g frr -d /var/log/frr \
+    && install -m 755 -o frr -g frr -d /var/run/frr \
+    && install -m 775 -o frr -g frrvty -d /etc/frr \
+    && install -m 640 -o frr -g frr /dev/null /etc/frr/zebra.conf \
+    && install -m 640 -o frr -g frr /dev/null /etc/frr/bgpd.conf \
+    && install -m 640 -o frr -g frr /dev/null /etc/frr/ospfd.conf \
+    && install -m 640 -o frr -g frr /dev/null /etc/frr/ospf6d.conf \
+    && install -m 640 -o frr -g frr /dev/null /etc/frr/isisd.conf \
+    && install -m 640 -o frr -g frr /dev/null /etc/frr/ripd.conf \
+    && install -m 640 -o frr -g frr /dev/null /etc/frr/ripngd.conf \
+    && install -m 640 -o frr -g frr /dev/null /etc/frr/pimd.conf \
+    && install -m 640 -o frr -g frr /dev/null /etc/frr/ldpd.conf \
+    && install -m 640 -o frr -g frr /dev/null /etc/frr/nhrpd.conf \
+    && install -m 640 -o frr -g frrvty /dev/null /etc/frr/vtysh.conf \
+    && echo "export VTYSH_PAGER=more" >>  /etc/bash.bashrc \
+    && echo "VTYSH_PAGER=more" >> /etc/environment
 
-RUN	touch /etc/quagga/bgpd.conf && \
-    touch /etc/quagga/ospfd.conf && \
-    touch /etc/quagga/vtysh.conf && \
-    touch /etc/quagga/zebra.conf
-
-
-# Add startup script and set it as entrypoint
-ADD docker-start /usr/sbin/docker-start
 COPY looking_glass.sh /home/.looking_glass.sh
-RUN chmod +x /usr/sbin/docker-start
-ENTRYPOINT ["/usr/sbin/docker-start"]
 
-# Draft for dockerfile using frr instead of quagga.
-# FROM d_base_supervisor:latest
+COPY supervisord.conf /etc/supervisor/conf.d/processes.conf
+COPY run_frr.sh /usr/local/bin/run_frr
+COPY run_ovs.sh /usr/local/bin/run_ovs
 
-# RUN apk add --no-cache openssh-server openvswitch frr frr-rpki frr-pythontools \
-#     && ssh-keygen -A \
-#     && sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config \
-#     && sed -i 's/#PrintMotd yes/PrintMotd no/g' /etc/ssh/sshd_config \
-#     # Unlocks the root user so that ssh login is allowed.
-#     && sed -i s/root:!/"root:*"/g /etc/shadow \
-#     && mkdir -p /var/run/sshd /root/.ssh \
-#     && chmod 0755 /var/run/sshd
-
-# RUN install -m 755 -o frr -g frr -d /var/log/frr \
-#     && install -m 755 -o frr -g frr -d /var/run/frr \
-#     && install -m 775 -o frr -g frrvty -d /etc/frr \
-#     && install -m 640 -o frr -g frr /dev/null /etc/frr/zebra.conf \
-#     && install -m 640 -o frr -g frr /dev/null /etc/frr/bgpd.conf \
-#     && install -m 640 -o frr -g frr /dev/null /etc/frr/ospfd.conf \
-#     && install -m 640 -o frr -g frr /dev/null /etc/frr/ospf6d.conf \
-#     && install -m 640 -o frr -g frr /dev/null /etc/frr/isisd.conf \
-#     && install -m 640 -o frr -g frr /dev/null /etc/frr/ripd.conf \
-#     && install -m 640 -o frr -g frr /dev/null /etc/frr/ripngd.conf \
-#     && install -m 640 -o frr -g frr /dev/null /etc/frr/pimd.conf \
-#     && install -m 640 -o frr -g frr /dev/null /etc/frr/ldpd.conf \
-#     && install -m 640 -o frr -g frr /dev/null /etc/frr/nhrpd.conf \
-#     && install -m 640 -o frr -g frrvty /dev/null /etc/frr/vtysh.conf \
-#     && echo "export VTYSH_PAGER=more" >>  /etc/bash.bashrc \
-#     && echo "VTYSH_PAGER=more" >> /etc/environment
-
-# # RUN echo "export VTYSH_PAGER=more" >>  /etc/bash.bashrc \
-# #     && echo "VTYSH_PAGER=more" >> /etc/environment \
-# #     && touch /etc/quagga/bgpd.conf \
-# #     && touch /etc/quagga/ospfd.conf \
-# #     && touch /etc/quagga/vtysh.conf \
-# #     && touch /etc/quagga/zebra.conf
-
-# COPY supervisord.conf /etc/supervisor/conf.d/processes.conf
-# COPY run_frr.sh /usr/local/bin/run_frr
-# COPY run_ovs.sh /usr/local/bin/run_ovs
-
-# RUN chmod +x /usr/local/bin/run_frr /usr/local/bin/run_ovs
+RUN chmod +x /usr/local/bin/run_frr /usr/local/bin/run_ovs

--- a/platform/docker_images/ixp/run_ovs.sh
+++ b/platform/docker_images/ixp/run_ovs.sh
@@ -23,6 +23,9 @@ sleep 2
 ovs-vsctl add-br IXP
 ovs-ofctl add-flow IXP action=NORMAL
 
+chmod 0755 /home/.looking_glass.sh
+/home/.looking_glass.sh &
+
 # Loop while the daemons are alive.
 # status returns exit code 0 only if all daemons are are running.
 while $command status > /dev/null ; do

--- a/platform/setup/container_setup.sh
+++ b/platform/setup/container_setup.sh
@@ -309,7 +309,7 @@ for ((k = 0; k < group_numbers; k++)); do
             location="${DIRECTORY}"/groups/g"${group_number}"
             docker run -itd --net='none' --name="${group_number}""_IXP" \
                 --pids-limit 200 --hostname "${group_number}""_IXP" \
-                -v "${location}"/daemons:/etc/quagga/daemons \
+                -v "${location}"/daemons:/etc/frr/daemons \
                 --privileged \
                 --sysctl net.ipv4.ip_forward=1 \
                 --sysctl net.ipv4.icmp_ratelimit=0 \

--- a/platform/setup/router_config.sh
+++ b/platform/setup/router_config.sh
@@ -217,20 +217,19 @@ for ((k = 0; k < group_numbers; k++)); do
                         subnet1="$(subnet_router_IXP ${grp_1} ${grp_2} group)"
                         subnet2="$(subnet_router_IXP ${grp_1} ${grp_2} IXP)"
 
-                        echo "ip community-list ${grp_1} permit ${grp_2}:${grp_1}"
+                        echo "bgp community-list ${grp_1} permit ${grp_2}:${grp_1}"
                         echo "route-map ${grp_1}_EXPORT permit 10"
-                        echo "set ip next-hop ${subnet1%/*}"
-                        echo "exit"
-                        echo "route-map ${grp_1}_IMPORT permit 10"
                         echo "match community ${grp_1}"
                         echo "exit"
+                        echo "route-map ${grp_1}_IMPORT permit 10"
+                        echo "exit"
                         echo "router bgp ${grp_2}"
-                        echo "bgp router-id 180.80.${grp_2}.0"
+                        echo "bgp router-id 180.${grp_2}.0.${grp_2}"
                         echo "neighbor ${subnet1%/*} remote-as ${grp_1}"
                         echo "neighbor ${subnet1%/*} activate"
                         echo "neighbor ${subnet1%/*} route-server-client"
-                        echo "neighbor ${subnet1%/*} route-map ${grp_1}_IMPORT import"
-                        echo "neighbor ${subnet1%/*} route-map ${grp_1}_EXPORT export"
+                        echo "neighbor ${subnet1%/*} route-map ${grp_1}_IMPORT in"
+                        echo "neighbor ${subnet1%/*} route-map ${grp_1}_EXPORT out"
                         echo "exit"
 
                         docker exec -d "${group_number}_IXP" bash -c "ovs-vsctl add-port IXP grp_${grp_1}"
@@ -293,6 +292,8 @@ for ((i = 0; i < n_extern_links; i++)); do
             echo "neighbor ${subnet2%???} activate"
             echo "neighbor ${subnet2%???} route-map IXP_OUT_${grp_2} out"
             echo "neighbor ${subnet2%???} route-map IXP_IN_${grp_2} in"
+            # The IXP does not add it's own AS to the AS_PATH which causes member rouers to drop routes from the IXP
+            echo "no neighbor ${subnet2%???} enforce-first-as"
             echo "exit"
 
             str_tmp=''

--- a/platform/setup/router_config.sh
+++ b/platform/setup/router_config.sh
@@ -197,7 +197,6 @@ for ((k = 0; k < group_numbers; k++)); do
             location="${configdir}/conf_full.sh"
 
             {
-                echo "bgp multiple-instance"
 
                 for ((i = 0; i < n_extern_links; i++)); do
                     row_i=(${extern_links[$i]})


### PR DESCRIPTION
To help future-proof the mini Internet project, it would make sense to migrate from Quagga to FRR for the route server.

Most of the changes come from a draft that was already present within the IXP Dockerfile. The remaining changes in the router config are related to the command syntax difference between Quagga and FRR.

It's important to note that this migration requires the routers connected to the IXP needs to include the `no neighbor IXP enforce-first-as` as documented [here](https://docs.frrouting.org/en/latest/bgp.html#clicmd-bgp-enforce-first-as). Without this, the router will deny updates received from the IXP as it does not list its AS number at the beginning of the AS_PATH. This means that any course content will also need to be updated to reflect this.