### PR TITLE
Replace the active polling for daemon status with passive waiting in switches/routers

### DIFF
--- a/platform/docker_images/base/Dockerfile
+++ b/platform/docker_images/base/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.19
 # and make bash the default shell.
 RUN apk add --no-cache tini bash bash-completion util-linux coreutils \
     binutils findutils grep vim nano tzdata \
-    iputils net-tools bind-tools iperf3 tcptraceroute tcpdump nmap nmap-nping \
+    iputils net-tools bind-tools iperf3 tcptraceroute tcpdump nmap nmap-nping python3 \
     && echo "export PS1=\"\[\033[38;5;2m\]\u@\h \[\033[38;5;75m\]\w\e[m> \"" > /root/.bashrc \
     && sed -i -e "s/bin\/ash/bin\/bash/" /etc/passwd
 

--- a/platform/docker_images/base_supervisor/Dockerfile
+++ b/platform/docker_images/base_supervisor/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache supervisor gawk tzdata \
 COPY supervisord.conf /etc/supervisor/supervisord.conf
 COPY stop-supervisord.sh /usr/local/bin/stop-supervisord
 COPY logger.sh /usr/local/bin/tail-supervisor-logs
+COPY wait-pidfds.py /usr/local/bin/wait-piddfs.py
 RUN chmod +x /usr/local/bin/stop-supervisord /usr/local/bin/tail-supervisor-logs
 
 ENV TZ="Europe/Paris"

--- a/platform/docker_images/base_supervisor/wait-pidfds.py
+++ b/platform/docker_images/base_supervisor/wait-pidfds.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+import glob
+import os
+import select
+import sys
+
+
+def read_pidfile(path: str) -> int | None:
+    try:
+        with open(path, "r", encoding="ascii") as f:
+            value = f.read().strip()
+    except FileNotFoundError:
+        return None
+
+    if not value:
+        return None
+
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} PID_DIR", file=sys.stderr)
+        return 2
+
+    pid_dir = sys.argv[1]
+    pidfiles = sorted(glob.glob(os.path.join(pid_dir, "*.pid")))
+
+    if not pidfiles:
+        print(f"error: no pidfiles found in {pid_dir}", file=sys.stderr)
+        return 1
+
+    poller = select.poll()
+    pidfds: dict[int, tuple[int, str]] = {}
+
+    for pidfile in pidfiles:
+        pid = read_pidfile(pidfile)
+
+        if pid is None:
+            # Empty, missing, or malformed pidfile: treat as stopped.
+            return 1
+
+        try:
+            pidfd = os.pidfd_open(pid, 0)
+        except ProcessLookupError:
+            # PID from pidfile is already gone.
+            return 1
+        except AttributeError:
+            print(
+                "error: Python does not support os.pidfd_open(); "
+                "need Linux + Python 3.9+",
+                file=sys.stderr,
+            )
+            return 2
+        except PermissionError as e:
+            print(
+                f"error: permission denied opening pidfd for PID {pid} "
+                f"from {pidfile}: {e}",
+                file=sys.stderr,
+            )
+            return 2
+
+        pidfds[pidfd] = (pid, pidfile)
+        poller.register(pidfd, select.POLLIN | select.POLLHUP | select.POLLERR)
+
+    try:
+        # Kernel-blocking wait. No busy loop.
+        events = poller.poll()
+
+        for pidfd, _event in events:
+            pid, pidfile = pidfds[pidfd]
+            print(
+                f"daemon process exited: pid={pid}, pidfile={pidfile}",
+                file=sys.stderr,
+            )
+
+        return 1
+    finally:
+        for pidfd in pidfds:
+            try:
+                os.close(pidfd)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/platform/docker_images/ixp/run_frr.sh
+++ b/platform/docker_images/ixp/run_frr.sh
@@ -3,8 +3,19 @@
 set -e
 
 command=/usr/lib/frr/frrinit.sh
+pid_dir="${FRR_PID_DIR:-/var/run/frr}"
+wait_helper="${WAIT_HELPER:-/usr/local/bin/wait-piddfs.py}"
+
+monitor_pid=""
 
 function stop() {
+    trap - SIGINT SIGTERM
+
+    if [ -n "${monitor_pid:-}" ]; then
+        kill "$monitor_pid" 2>/dev/null || true
+        wait "$monitor_pid" 2>/dev/null || true
+    fi
+
     $command stop
     exit 0
 }
@@ -20,12 +31,30 @@ trap "reload" SIGHUP
 $command start
 sleep 2
 
-# Loop while the daemons are alive.
-# status returns exit code 0 only if all daemons are are running.
-while $command status > /dev/null ; do
-    sleep 0.5
-done
+# Validate initial state once.
+# This preserves the old behavior that startup fails if any daemon is not alive.
+if ! $command status > /dev/null; then
+    $command status
+    exit 1
+fi
 
-$command status
+# Block until any currently-running FRR daemon exits.
+python3 "$wait_helper" "$pid_dir" &
+monitor_pid=$!
 
-exit 1 # exit unexpected
+if wait "$monitor_pid"; then
+    # The helper should not normally exit 0.
+    $command status
+    exit 1
+else
+    rc=$?
+
+    # rc=1 means one daemon exited, or was already gone.
+    if [ "$rc" -eq 1 ]; then
+        $command status
+        exit 1
+    fi
+
+    # rc=2 means unsupported platform / permission / helper setup error.
+    exit "$rc"
+fi

--- a/platform/docker_images/ixp/run_ovs.sh
+++ b/platform/docker_images/ixp/run_ovs.sh
@@ -3,8 +3,19 @@
 set -e
 
 command=/usr/share/openvswitch/scripts/ovs-ctl
+pid_dir="${OVS_PID_DIR:-/var/run/openvswitch}"
+wait_helper="${WAIT_HELPER:-/usr/local/bin/wait-piddfs.py}"
+
+monitor_pid=""
 
 function stop() {
+    trap - SIGINT SIGTERM
+
+    if [ -n "${monitor_pid:-}" ]; then
+        kill "$monitor_pid" 2>/dev/null || true
+        wait "$monitor_pid" 2>/dev/null || true
+    fi
+
     $command stop
     exit 0
 }
@@ -26,12 +37,30 @@ ovs-ofctl add-flow IXP action=NORMAL
 chmod 0755 /home/.looking_glass.sh
 /home/.looking_glass.sh &
 
-# Loop while the daemons are alive.
-# status returns exit code 0 only if all daemons are are running.
-while $command status > /dev/null ; do
-    sleep 0.5
-done
+# Validate initial state once.
+# This preserves the old behavior that startup fails if any daemon is not alive.
+if ! $command status > /dev/null; then
+    $command status
+    exit 1
+fi
 
-$command status
+# Block until any currently-running FRR daemon exits.
+python3 "$wait_helper" "$pid_dir" &
+monitor_pid=$!
 
-exit 1 # exit unexpected
+if wait "$monitor_pid"; then
+    # The helper should not normally exit 0.
+    $command status
+    exit 1
+else
+    rc=$?
+
+    # rc=1 means one daemon exited, or was already gone.
+    if [ "$rc" -eq 1 ]; then
+        $command status
+        exit 1
+    fi
+
+    # rc=2 means unsupported platform / permission / helper setup error.
+    exit "$rc"
+fi

--- a/platform/docker_images/router/run_frr.sh
+++ b/platform/docker_images/router/run_frr.sh
@@ -3,8 +3,19 @@
 set -e
 
 command=/usr/lib/frr/frrinit.sh
+pid_dir="${FRR_PID_DIR:-/var/run/frr}"
+wait_helper="${WAIT_HELPER:-/usr/local/bin/wait-piddfs.py}"
+
+monitor_pid=""
 
 function stop() {
+    trap - SIGINT SIGTERM
+
+    if [ -n "${monitor_pid:-}" ]; then
+        kill "$monitor_pid" 2>/dev/null || true
+        wait "$monitor_pid" 2>/dev/null || true
+    fi
+
     $command stop
     exit 0
 }
@@ -20,12 +31,30 @@ trap "reload" SIGHUP
 $command start
 sleep 2
 
-# Loop while the daemons are alive.
-# status returns exit code 0 only if all daemons are are running.
-while $command status > /dev/null ; do
-    sleep 0.5
-done
+# Validate initial state once.
+# This preserves the old behavior that startup fails if any daemon is not alive.
+if ! $command status > /dev/null; then
+    $command status
+    exit 1
+fi
 
-$command status
+# Block until any currently-running FRR daemon exits.
+python3 "$wait_helper" "$pid_dir" &
+monitor_pid=$!
 
-exit 1 # exit unexpected
+if wait "$monitor_pid"; then
+    # The helper should not normally exit 0.
+    $command status
+    exit 1
+else
+    rc=$?
+
+    # rc=1 means one daemon exited, or was already gone.
+    if [ "$rc" -eq 1 ]; then
+        $command status
+        exit 1
+    fi
+
+    # rc=2 means unsupported platform / permission / helper setup error.
+    exit "$rc"
+fi

--- a/platform/docker_images/switch/run_ovs.sh
+++ b/platform/docker_images/switch/run_ovs.sh
@@ -3,8 +3,19 @@
 set -e
 
 command=/usr/share/openvswitch/scripts/ovs-ctl
+pid_dir="${OVS_PID_DIR:-/var/run/openvswitch}"
+wait_helper="${WAIT_HELPER:-/usr/local/bin/wait-piddfs.py}"
+
+monitor_pid=""
 
 function stop() {
+    trap - SIGINT SIGTERM
+
+    if [ -n "${monitor_pid:-}" ]; then
+        kill "$monitor_pid" 2>/dev/null || true
+        wait "$monitor_pid" 2>/dev/null || true
+    fi
+
     $command stop
     exit 0
 }
@@ -20,12 +31,30 @@ trap "restart" SIGHUP
 $command start
 sleep 2
 
-# Loop while the daemons are alive.
-# status returns exit code 0 only if all daemons are are running.
-while $command status > /dev/null ; do
-    sleep 0.5
-done
+# Validate initial state once.
+# This preserves the old behavior that startup fails if any daemon is not alive.
+if ! $command status > /dev/null; then
+    $command status
+    exit 1
+fi
 
-$command status
+# Block until any currently-running FRR daemon exits.
+python3 "$wait_helper" "$pid_dir" &
+monitor_pid=$!
 
-exit 1 # exit unexpected
+if wait "$monitor_pid"; then
+    # The helper should not normally exit 0.
+    $command status
+    exit 1
+else
+    rc=$?
+
+    # rc=1 means one daemon exited, or was already gone.
+    if [ "$rc" -eq 1 ]; then
+        $command status
+        exit 1
+    fi
+
+    # rc=2 means unsupported platform / permission / helper setup error.
+    exit "$rc"
+fi


### PR DESCRIPTION
This PR replaces the active polling processes for `ovs-ctl status` and `frr-init.sh status` with pid_fds which wait on changes to the daemon processes. 

All original behaviour is kept and the status commands are still run once a change has been detected by the pid_fds.

This change reduced the CPU usage for our deployment with over 3000 containers from 80% to 30% on a 128-core system. Load factor was reduced from over 1000 to 500, increasing reactiveness of the system significantly.

The change requires adding python to the base image, slightly increasing its size. Due to docker overlayfs, this 50MB increase is only stored once and not added for every container.

Fixes #60. 